### PR TITLE
Add a command to delete Docker tags

### DIFF
--- a/src/cmd/docker_hub.go
+++ b/src/cmd/docker_hub.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type dockerTag struct {
+	name string
+	size uint64
+	date time.Time
+}
+
+func getAllTags(image string) []dockerTag {
+
+	var results []dockerTag
+
+	reqURL := "https://hub.docker.com/v2/repositories/" + image + "/tags/?page_size=100"
+
+	for {
+
+		req, err := http.NewRequest("GET", reqURL, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		resp, err := sendRequest(req, "", "")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		var respPage map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&respPage)
+
+		for _, v := range respPage["results"].([]interface{}) {
+
+			var aTag dockerTag
+
+			aTag.name = v.(map[string]interface{})["name"].(string)
+			aTag.size = uint64(v.(map[string]interface{})["full_size"].(float64))
+			aTag.date, err = time.Parse(time.RFC3339, v.(map[string]interface{})["last_updated"].(string))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			results = append(results, aTag)
+		}
+
+		if respPage["next"] == nil {
+			break
+		} else {
+			reqURL = respPage["next"].(string)
+		}
+	}
+
+	return results
+}

--- a/src/cmd/tags_delete.go
+++ b/src/cmd/tags_delete.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	dryRunFl bool
+	fieldFl  string
+	gtFl     string
+	ltFl     string
+
+	tagsDeleteCmd = &cobra.Command{
+		Use:   "delete <image-name>",
+		Short: "Deletes one or more tags based on a parameter",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if len(args) == 0 {
+				log.Fatal("Please provide a Docker image name.")
+				os.Exit(1)
+			}
+
+			if fieldFl != "date" {
+				log.Fatal("'field' is a required field and must be 'date'.")
+				os.Exit(1)
+			}
+
+			if gtFl == "" && ltFl == "" {
+				log.Fatal("Either the 'gt' or 'lt' flags need to be set.")
+				os.Exit(1)
+			}
+
+			gDuration, err := time.ParseDuration(gtFl)
+			if err != nil {
+				fmt.Errorf("Cannot parse duration from 'gt'", err)
+			}
+			gCutDate := time.Now().Add(-gDuration)
+
+			lDuration, err := time.ParseDuration(ltFl)
+			if err != nil {
+				fmt.Errorf("Cannot parse duration from 'lt'", err)
+			}
+			lCutDate := time.Now().Add(-lDuration)
+
+			dockerTags := getAllTags(args[0])
+			var tagsToDelete []dockerTag
+
+			for _, tag := range dockerTags {
+
+				if gtFl != "" && fieldFl == "date" {
+					if gCutDate.After(tag.date) {
+						tagsToDelete = append(tagsToDelete, tag)
+					}
+				}
+
+				if ltFl != "" && fieldFl == "date" {
+					if lCutDate.Before(tag.date) {
+						tagsToDelete = append(tagsToDelete, tag)
+					}
+				}
+			}
+
+			if len(tagsToDelete) == 0 {
+
+				fmt.Println("There were no tags to delete.")
+				return
+			}
+
+			if dryRunFl {
+
+				fmt.Println("The tags that would have been deleted: ")
+				for _, tag := range tagsToDelete {
+					fmt.Println(tag.name)
+				}
+
+				return
+			}
+
+			fmt.Printf("You are about to permanently delete %d tags. Continue? [y/yes/n/no] ", len(tagsToDelete))
+			scanner := bufio.NewScanner(os.Stdin)
+			for scanner.Scan() {
+				if scanner.Text() == "n" || scanner.Text() == "no" {
+					fmt.Println("Cancelling.")
+					return
+				} else if scanner.Text() == "y" || scanner.Text() == "yes" {
+					break
+				} else {
+					fmt.Println("Invalid input. Try again.")
+				}
+			}
+
+			for _, tag := range tagsToDelete {
+				err := deleteDockerTag(args[0], tag.name)
+				if err != nil {
+					log.Error(err)
+				}
+			}
+		},
+	}
+)
+
+func init() {
+
+	tagsDeleteCmd.Flags().BoolVar(&dryRunFl, "dry-run", false, "show what would be deleted without actually deleting any tags")
+	tagsDeleteCmd.Flags().StringVar(&fieldFl, "field", "name", "the field to filter what will be deleted. Only 'date' is supported right now.")
+	tagsDeleteCmd.Flags().StringVar(&gtFl, "gt", "", "delete tags 'greater than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
+	tagsDeleteCmd.Flags().StringVar(&ltFl, "lt", "", "delete tags 'less than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
+
+	tagsCmd.AddCommand(tagsDeleteCmd)
+}
+
+func deleteDockerTag(image, tag string) error {
+
+	req, err := http.NewRequest("DELETE", "https://hub.docker.com/v2/repositories/"+image+"/tags/"+tag+"/", nil)
+	if err != nil {
+		return errors.New("Failed to create DELETE request.")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	if len(viper.Get("user").(string)) == 0 || len(viper.Get("pass").(string)) == 0 {
+		return errors.New("This command requires Docker Hub credentials to be set in your environment.")
+	}
+
+	resp, err := sendRequest(req, viper.Get("user").(string), viper.Get("pass").(string))
+	if err != nil {
+		return (err)
+	}
+	defer resp.Body.Close()
+
+	code := resp.StatusCode
+	if err != nil {
+		return err
+	}
+
+	if code != 204 {
+		return errors.New("There was an error in deleting the tag: " + tag)
+	}
+
+	return nil
+}

--- a/src/cmd/tags_list.go
+++ b/src/cmd/tags_list.go
@@ -21,6 +21,7 @@ var tagsListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// The loop logic should use the new function "getAllTags" in the future
 		reqURL := "https://hub.docker.com/v2/repositories/" + args[0] + "/tags/?page_size=100"
 		var results []string
 


### PR DESCRIPTION
This new command 'tags delete' will delete Docker tags from a specified
image. In this first iteration, it will only delete a group of tags that
are older than or newer than a set time duration.

Such as these two examples:

```bash
sonar tags delete my/image --field=date --gt=48h
sonar tags delete my/image --field=date --lt=30m
```