### PR TITLE
Add size and total to tags list.

### DIFF
--- a/src/cmd/tags_list.go
+++ b/src/cmd/tags_list.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,55 +9,41 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var tagsListCmd = &cobra.Command{
-	Use:   "list <image-name>",
-	Short: "Displays tags for a given Docker image name",
-	Run: func(cmd *cobra.Command, args []string) {
+var (
+	sumSizeFl bool
 
-		if len(args) == 0 {
-			log.Fatal("Please provide a Docker image name.")
-			os.Exit(1)
-		}
+	tagsListCmd = &cobra.Command{
+		Use:   "list <image-name>",
+		Short: "Displays tags for a given Docker image name",
+		Run: func(cmd *cobra.Command, args []string) {
 
-		// The loop logic should use the new function "getAllTags" in the future
-		reqURL := "https://hub.docker.com/v2/repositories/" + args[0] + "/tags/?page_size=100"
-		var results []string
-
-		for {
-
-			req, err := http.NewRequest("GET", reqURL, nil)
-			if err != nil {
-				log.Fatal(err)
+			if len(args) == 0 {
+				log.Fatal("Please provide a Docker image name.")
+				os.Exit(1)
 			}
 
-			resp, err := sendRequest(req, "", "")
-			if err != nil {
-				log.Fatal(err)
+			dockerTags := getAllTags(args[0])
+
+			fmt.Println("The tags are: ")
+			var totalSize uint64
+
+			for _, tag := range dockerTags {
+				fmt.Println(tag.name)
+				if sumSizeFl {
+					totalSize += uint64(tag.size)
+				}
 			}
-			defer resp.Body.Close()
 
-			var respPage map[string]interface{}
-			json.NewDecoder(resp.Body).Decode(&respPage)
-
-			for _, v := range respPage["results"].([]interface{}) {
-				results = append(results, v.(map[string]interface{})["name"].(string))
+			fmt.Printf("Total tags: %d\n", len(dockerTags))
+			if sumSizeFl {
+				fmt.Printf("Total size: %s\n", ByteCountBinary(totalSize))
 			}
-
-			if respPage["next"] == nil {
-				break
-			} else {
-				reqURL = respPage["next"].(string)
-			}
-		}
-
-		fmt.Println("The tags are: ")
-
-		for _, tag := range results {
-			fmt.Println(tag)
-		}
-	},
-}
+		},
+	}
+)
 
 func init() {
+	tagsListCmd.Flags().BoolVar(&sumSizeFl, "sum-size", false, "output the storage size of tags")
+
 	tagsCmd.AddCommand(tagsListCmd)
 }

--- a/src/cmd/util.go
+++ b/src/cmd/util.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "fmt"
+
+func ByteCountBinary(b uint64) string {
+
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}


### PR DESCRIPTION
Improves the list subcommand to use the same logic as the delete subcommand. Then adds the total tags and optionally, size to the output.