### PR TITLE
Move tags delete filter flags to parent command.

### DIFF
--- a/src/cmd/tags.go
+++ b/src/cmd/tags.go
@@ -4,11 +4,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var tagsCmd = &cobra.Command{
-	Use:   "tags",
-	Short: "A group of commands related to Docker image tags",
-}
+var (
+	fieldFl string
+	gtFl    string
+	ltFl    string
+
+	tagsCmd = &cobra.Command{
+		Use:   "tags",
+		Short: "A group of commands related to Docker image tags",
+	}
+)
 
 func init() {
+
+	tagsCmd.PersistentFlags().StringVar(&fieldFl, "field", "", "the field to filter what tags will be selected. Only 'date' is supported right now.")
+	tagsCmd.PersistentFlags().StringVar(&gtFl, "gt", "", "filter tags 'greater than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
+	tagsCmd.PersistentFlags().StringVar(&ltFl, "lt", "", "filter tags 'less than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
+
 	rootCmd.AddCommand(tagsCmd)
 }

--- a/src/cmd/tags_delete.go
+++ b/src/cmd/tags_delete.go
@@ -16,9 +16,6 @@ import (
 
 var (
 	dryRunFl bool
-	fieldFl  string
-	gtFl     string
-	ltFl     string
 	yesFl    bool
 
 	tagsDeleteCmd = &cobra.Command{
@@ -117,9 +114,6 @@ var (
 func init() {
 
 	tagsDeleteCmd.Flags().BoolVar(&dryRunFl, "dry-run", false, "show what would be deleted without actually deleting any tags")
-	tagsDeleteCmd.Flags().StringVar(&fieldFl, "field", "name", "the field to filter what will be deleted. Only 'date' is supported right now.")
-	tagsDeleteCmd.Flags().StringVar(&gtFl, "gt", "", "delete tags 'greater than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
-	tagsDeleteCmd.Flags().StringVar(&ltFl, "lt", "", "delete tags 'less than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
 	tagsDeleteCmd.Flags().BoolVarP(&yesFl, "yes", "y", false, "automatic yes to deletion prompt, useful for scripting")
 
 	tagsCmd.AddCommand(tagsDeleteCmd)


### PR DESCRIPTION
The filter flags from the `tags delete` command can also apply to `tags list`. Moving them to the parent command so that the flags can be shared.