### PR TITLE
Support higher durations

### DIFF
--- a/src/cmd/tags.go
+++ b/src/cmd/tags.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -18,8 +22,39 @@ var (
 func init() {
 
 	tagsCmd.PersistentFlags().StringVar(&fieldFl, "field", "", "the field to filter what tags will be selected. Only 'date' is supported right now.")
-	tagsCmd.PersistentFlags().StringVar(&gtFl, "gt", "", "filter tags 'greater than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
-	tagsCmd.PersistentFlags().StringVar(&ltFl, "lt", "", "filter tags 'less than' this value - allowed values is based on the 'field' choosen. A relative time in seconds, minutes, or hours is supported.")
+	tagsCmd.PersistentFlags().StringVar(&gtFl, "gt", "", "filter tags 'greater than' this value - allowed values are based on the 'field' choosen. A relative time in seconds (s), minutes (m), hours (h), days (d), or weeks (w) is supported.")
+	tagsCmd.PersistentFlags().StringVar(&ltFl, "lt", "", "filter tags 'less than' this value - allowed values are based on the 'field' choosen. A relative time in seconds (s), minutes (m), hours (h), days (d), or weeks (w) is supported.")
 
 	rootCmd.AddCommand(tagsCmd)
+}
+
+// This is a wrapper for time.ParseDuration that adds support for days and weeks
+func parseDuration(duration string) (time.Duration, error) {
+
+	if duration == "" {
+		return time.ParseDuration(duration)
+	}
+
+	cutPoint := len(duration) - 1
+	fmt.Printf("cutPoint: %d\n", cutPoint) //DEBUG
+	var multiple int
+
+	if duration[cutPoint:] == "d" {
+		multiple = 24 // number of hours in a day
+	} else if duration[cutPoint:] == "w" {
+		multiple = 24 * 7 // number of hours in a week
+	}
+
+	integer, err := strconv.Atoi(duration[:cutPoint])
+	if err != nil {
+		return 0, err
+	}
+
+	if multiple != 0 {
+		fmt.Printf("The number of hours is: %dh\n", integer*multiple) //DEBUG
+		fmt.Printf("The integer is: %d\n", integer)                   //DEBUG
+		return time.ParseDuration(strconv.Itoa(integer*multiple) + "h")
+	}
+
+	return time.ParseDuration(duration)
 }

--- a/src/cmd/tags_delete.go
+++ b/src/cmd/tags_delete.go
@@ -38,13 +38,13 @@ var (
 				os.Exit(1)
 			}
 
-			gDuration, err := time.ParseDuration(gtFl)
+			gDuration, err := parseDuration(gtFl)
 			if err != nil {
 				fmt.Errorf("Cannot parse duration from 'gt'", err)
 			}
 			gCutDate := time.Now().Add(-gDuration)
 
-			lDuration, err := time.ParseDuration(ltFl)
+			lDuration, err := parseDuration(ltFl)
 			if err != nil {
 				fmt.Errorf("Cannot parse duration from 'lt'", err)
 			}

--- a/src/cmd/tags_list.go
+++ b/src/cmd/tags_list.go
@@ -28,13 +28,13 @@ var (
 				os.Exit(1)
 			}
 
-			gDuration, err := time.ParseDuration(gtFl)
+			gDuration, err := parseDuration(gtFl)
 			if err != nil {
 				fmt.Errorf("Cannot parse duration from 'gt'", err)
 			}
 			gCutDate := time.Now().Add(-gDuration)
 
-			lDuration, err := time.ParseDuration(ltFl)
+			lDuration, err := parseDuration(ltFl)
 			if err != nil {
 				fmt.Errorf("Cannot parse duration from 'lt'", err)
 			}


### PR DESCRIPTION
In the 'tags' subcommands, a duration filter is supported. Out of the
box with Go, only up to hours is supported. This PR adds support for
days and weeks.

Closes #17.