### PR TITLE
Add support for Python Pip packages.

### DIFF
--- a/sonar/cmd/packages.go
+++ b/sonar/cmd/packages.go
@@ -4,6 +4,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type packageInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Manager string `json:"manager"`
+	Source  string `json:"source"`
+}
+
 var (
 	packagesCmd = &cobra.Command{
 		Use:     "packages",

--- a/sonar/cmd/packages_compile.go
+++ b/sonar/cmd/packages_compile.go
@@ -2,44 +2,112 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"os/exec"
 
 	"github.com/arduino/go-apt-client"
 	"github.com/spf13/cobra"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
+	aptFl bool
+	pipFl bool
+
 	packagesCompileCmd = &cobra.Command{
 		Use:    "compile",
 		Short:  "Displays installed packages for the system",
-		Long:   "Currently only supports Apt packages",
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			packages := listPackages()
+			if pipFl {
+				packages := listPackagesPip()
 
-			jsonFile, _ := json.MarshalIndent(packages, "", "")
-			_ = ioutil.WriteFile("/sonar-packages.json", jsonFile, 0644)
+				for _, pkg := range packages {
+					fmt.Printf("%s: %s\n", pkg.Name, pkg.Version)
+				}
+
+				jsonFile, _ := json.Marshal(packages)
+				fmt.Printf("%s", string(jsonFile))
+				_ = ioutil.WriteFile("/tmp/sonar-packages.json", jsonFile, 0644)
+			} else {
+
+				packages := listPackages()
+
+				jsonFile, _ := json.Marshal(packages)
+				fmt.Printf("%s", string(jsonFile))
+				_ = ioutil.WriteFile("/tmp/sonar-packages.json", jsonFile, 0644)
+			}
 		},
 	}
 )
 
 func init() {
+	packagesCompileCmd.Flags().BoolVar(&aptFl, "apt", true, "show apt packages?")
+	packagesCompileCmd.Flags().BoolVar(&pipFl, "pip", false, "show pip packages?")
+
 	packagesCmd.AddCommand(packagesCompileCmd)
 }
 
-func listPackages() []string {
+func listPackages() []packageInfo {
 
-	var packages []string
+	var packages []packageInfo
 
 	allPackages, _ := apt.List()
 
 	for _, pkg := range allPackages {
 
 		if pkg.Status == "installed" {
-			packages = append(packages, pkg.Name)
+
+			packages = append(packages, packageInfo{
+				Name:    pkg.Name,
+				Version: pkg.Version,
+				Manager: "apt",
+			})
 		}
 	}
 
 	return packages
+}
+
+func listPackagesPip() []packageInfo {
+
+	var pipJSON []map[string]string
+	var packages []packageInfo
+
+	for _, pipCmd := range []string{"pip", "pip3"} {
+
+		if !commandExists(pipCmd) {
+			continue
+		}
+
+		output, err := exec.Command(pipCmd, "list", "--format=json").Output()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = json.Unmarshal(output, &pipJSON)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, pkg := range pipJSON {
+			packages = append(packages, packageInfo{
+				Name:    pkg["name"],
+				Version: pkg["version"],
+				Manager: "pip",
+			})
+		}
+	}
+
+	return packages
+}
+
+func commandExists(command string) bool {
+
+	_, err := exec.LookPath(command)
+
+	return err == nil
 }

--- a/sonar/cmd/packages_list.go
+++ b/sonar/cmd/packages_list.go
@@ -94,7 +94,7 @@ var (
 			var buf2 bytes.Buffer
 			if err := client.DownloadFromContainer(container.ID, docker.DownloadFromContainerOptions{
 				OutputStream: &buf2,
-				Path:         "/sonar-packages.json",
+				Path:         "/tmp/sonar-packages.json",
 			}); err != nil {
 				log.Error("Error: Failed")
 				log.Fatal(err)


### PR DESCRIPTION
Closes #59.

Adds support for Python Pip packages to the packages command. Utilizes packages installed with both `pip` and `pip3` in the image.