### PR TITLE
Fix: handle nil tag digests

### DIFF
--- a/sonar/docker/tag.go
+++ b/sonar/docker/tag.go
@@ -43,7 +43,14 @@ func GetAllTags(image string) ([]Tag, error) {
 			aTag.Size = uint64(v.(map[string]interface{})["full_size"].(float64))
 			aTag.Date, err = time.Parse(time.RFC3339, v.(map[string]interface{})["last_updated"].(string))
 			anImage := v.(map[string]interface{})["images"].([]interface{})[0]
-			aTag.Digest = anImage.(map[string]interface{})["digest"].(string)
+
+			// There are cases where the digest for a tag can be missing. Not
+			// sure why. Until then, check for this edge case and set to an
+			// empty string (don't set) when digest isn't available.
+			if anImage.(map[string]interface{})["digest"] != nil {
+				aTag.Digest = anImage.(map[string]interface{})["digest"].(string)
+			}
+
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes #116 

I thought Sonar couldn't handle large tag amounts. It turns out, there's an edge case where a tag can be returned without a digest. I'm not sure why, if this is a bug on Docker Hub's end, or what. Regardless, it's now handled in Sonar so that it doesn't panic anymore.