### PR TITLE
Check validity of an image tag

### DIFF
--- a/sonar/cmd/layers_list.go
+++ b/sonar/cmd/layers_list.go
@@ -20,6 +20,11 @@ var layersListCmd = &cobra.Command{
 			return fmt.Errorf("%s", err)
 		}
 
+		if validity, err := image.Valid(); validity != true {
+
+			return err
+		}
+
 		image.ShowTag = false
 
 		dockerLayers, err := docker.GetAllLayers(image.String(), image.Tag)


### PR DESCRIPTION
Fixes #140

Turns out that the reported issue was not exactly correct. The `latest` tag was correct, but that tag doesn't exists. This PR now adds the ability for an image to check if its valid and we now use this result to return an error message.